### PR TITLE
Cc/phpcompatabilityfix

### DIFF
--- a/class.geoswitch.php
+++ b/class.geoswitch.php
@@ -105,7 +105,8 @@ class GeoSwitch {
 
     public static function get_state($atts, $content) {
         if(self::existing_state_cookie()){
-            return self::get_state_cookie()['name'];
+            $state_cookie = self::get_state_cookie();
+            return $state_cookie['name'];
         }else{
             if (is_null(self::$record)) {
                 return '?';
@@ -116,7 +117,8 @@ class GeoSwitch {
 
     public static function get_state_code($atts, $content) {
         if(self::existing_state_cookie()){
-            return self::get_state_cookie()['code'];
+            $state_cookie = self::get_state_cookie();
+            return $state_cookie()['code'];
         }else{
             if (is_null(self::$record)) {
                 return '?';

--- a/class.geoswitch.php
+++ b/class.geoswitch.php
@@ -118,7 +118,7 @@ class GeoSwitch {
     public static function get_state_code($atts, $content) {
         if(self::existing_state_cookie()){
             $state_cookie = self::get_state_cookie();
-            return $state_cookie()['code'];
+            return $state_cookie['code'];
         }else{
             if (is_null(self::$record)) {
                 return '?';


### PR DESCRIPTION
@ninjapanzer 

As we have already discussed the changes here, WRT - PHP on the production boxes is set to 5.3 and the plugin was developed under >5.4, I am going to merge the changes back to master.  I am going to open an action item for the issue, and query @BobTheBotMaker WRT updating php on all wordpress host environments. 
